### PR TITLE
Add basic sync listeners

### DIFF
--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -2,6 +2,9 @@ import { declareIndexPlugin, ReactRNPlugin, WidgetLocation } from '@remnote/plug
 import '../style.css';
 import '../App.css';
 
+// Timer reference for cleanup on deactivation
+let syncInterval: ReturnType<typeof setInterval> | undefined;
+
 async function onActivate(plugin: ReactRNPlugin) {
   // Register settings
   await plugin.settings.registerStringSetting({
@@ -38,8 +41,41 @@ async function onActivate(plugin: ReactRNPlugin) {
   await plugin.app.registerWidget('sample_widget', WidgetLocation.RightSidebar, {
     dimensions: { height: 'auto', width: '100%' },
   });
+
+  // Listen for Rem changes to detect flashcard edits
+  await plugin.event.addListener('RemChanged', 'sync-rem-changed', (payload) => {
+    console.log('RemChanged event', payload);
+  });
+
+  // Listen for completed cards in the queue
+  await plugin.event.addListener(
+    'queue.complete-card',
+    'sync-complete-card',
+    (payload) => {
+      console.log('Queue complete-card event', payload);
+    }
+  );
+
+  // Listen for queue load events (optional)
+  await plugin.event.addListener('queue.load-card', 'sync-load-card', (payload) => {
+    console.log('Queue load-card event', payload);
+  });
+
+  // Basic timer to demonstrate cleanup
+  syncInterval = setInterval(() => {
+    console.log('Periodic timer fired');
+  }, 60 * 1000);
 }
 
-async function onDeactivate(_: ReactRNPlugin) {}
+async function onDeactivate(plugin: ReactRNPlugin) {
+  await plugin.event.removeListener('RemChanged', 'sync-rem-changed');
+  await plugin.event.removeListener('queue.complete-card', 'sync-complete-card');
+  await plugin.event.removeListener('queue.load-card', 'sync-load-card');
+
+  if (syncInterval) {
+    clearInterval(syncInterval);
+    syncInterval = undefined;
+  }
+}
 
 declareIndexPlugin(onActivate, onDeactivate);

--- a/src/widgets/sample_widget.tsx
+++ b/src/widgets/sample_widget.tsx
@@ -1,4 +1,8 @@
-import { usePlugin, renderWidget, useTracker } from '@remnote/plugin-sdk';
+import {
+  usePlugin,
+  renderWidget,
+  useTrackerPlugin as useTracker,
+} from '@remnote/plugin-sdk';
 
 export const SampleWidget = () => {
   const plugin = usePlugin();


### PR DESCRIPTION
## Summary
- register listeners for RemChanged, queue.complete-card, and queue.load-card
- log event payloads and set up a simple timer
- clean up listeners and timer on deactivate
- fix sample widget hook import

## Testing
- `npm run check-types`