### PR TITLE
Add markdown helpers and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "check-types": "tsc",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --color --progress --no-open",
-    "build": "npx remnote-plugin validate && shx rm -rf dist && cross-env NODE_ENV=production webpack --color --progress && shx cp README.md dist && cd dist && bestzip ../PluginZip.zip ./*"
+    "build": "npx remnote-plugin validate && shx rm -rf dist && cross-env NODE_ENV=production webpack --color --progress && shx cp README.md dist && cd dist && bestzip ../PluginZip.zip ./*",
+    "test": "ts-node tests/markdown.test.ts"
   },
   "dependencies": {
     "@remnote/plugin-sdk": "latest",

--- a/src/github/markdown.ts
+++ b/src/github/markdown.ts
@@ -1,0 +1,96 @@
+export interface SimpleCard {
+  _id: string;
+  remId: string;
+  nextRepetitionTime?: number;
+  lastRepetitionTime?: number;
+  // FSRS fields
+  difficulty?: number;
+  stability?: number;
+}
+
+export interface SimpleRem {
+  _id: string;
+  text?: string;
+  backText?: string;
+  tags?: string[];
+}
+
+export interface ParsedCard {
+  cardId: string;
+  remId: string;
+  tags: string[];
+  scheduler?: string | null;
+  difficulty?: number | null;
+  stability?: number | null;
+  lastReviewed?: string | null;
+  nextDue?: string | null;
+  question: string;
+  answer: string;
+}
+
+/**
+ * Serialize a card/rem pair to a markdown string with YAML frontmatter.
+ */
+export function serializeCard(card: SimpleCard, rem: SimpleRem): string {
+  const frontmatter: Record<string, any> = {
+    remId: rem._id,
+    cardId: card._id,
+    tags: rem.tags ?? [],
+    scheduler: 'FSRS',
+    difficulty: card.difficulty ?? null,
+    stability: card.stability ?? null,
+    lastReviewed: card.lastRepetitionTime
+      ? new Date(card.lastRepetitionTime).toISOString()
+      : null,
+    nextDue: card.nextRepetitionTime
+      ? new Date(card.nextRepetitionTime).toISOString()
+      : null,
+  };
+
+  const yaml = require('yaml');
+  const front = yaml.stringify(frontmatter).trimEnd();
+  const question = rem.text ?? '';
+  const answer = rem.backText ?? '';
+  return `---\n${front}\n---\n**Q:** ${question}\n\n**A:** ${answer}\n`;
+}
+
+/**
+ * Parse a markdown string created by `serializeCard` back into its components.
+ */
+export function parseCardMarkdown(content: string): ParsedCard {
+  const yaml = require('yaml');
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!fmMatch) {
+    throw new Error('Invalid card markdown: missing frontmatter');
+  }
+  const front = yaml.parse(fmMatch[1]) as Record<string, any>;
+  const body = fmMatch[2];
+  const lines = body.split(/\r?\n/);
+  const qIndex = lines.findIndex((l) => l.startsWith('**Q:**'));
+  const aIndex = lines.findIndex((l) => l.startsWith('**A:**'));
+  if (qIndex === -1 || aIndex === -1 || aIndex < qIndex) {
+    throw new Error('Invalid card markdown: missing Q/A');
+  }
+  const question = lines
+    .slice(qIndex, aIndex)
+    .join('\n')
+    .replace(/^\*\*Q:\*\*\s*/, '')
+    .trim();
+  const answer = lines
+    .slice(aIndex)
+    .join('\n')
+    .replace(/^\*\*A:\*\*\s*/, '')
+    .trim();
+  return {
+    cardId: front.cardId,
+    remId: front.remId,
+    tags: front.tags ?? [],
+    scheduler: front.scheduler,
+    difficulty: front.difficulty ?? null,
+    stability: front.stability ?? null,
+    lastReviewed: front.lastReviewed ?? null,
+    nextDue: front.nextDue ?? null,
+    question,
+    answer,
+  };
+}

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import { serializeCard, parseCardMarkdown, SimpleCard, SimpleRem } from '../src/github/markdown';
+
+const card: SimpleCard = {
+  _id: 'card-efgh5678',
+  remId: 'rem-abcd1234',
+  difficulty: 5.6,
+  stability: 15.2,
+  lastRepetitionTime: Date.parse('2025-04-10T09:30:00Z'),
+  nextRepetitionTime: Date.parse('2025-05-10T09:30:00Z'),
+};
+
+const rem: SimpleRem = {
+  _id: 'rem-abcd1234',
+  text: 'Why does the sky appear blue during the day?',
+  backText: 'Rayleigh scattering causes blue light to dominate the sky.',
+  tags: ['Astronomy', 'LightScattering'],
+};
+
+const md = serializeCard(card, rem);
+const parsed = parseCardMarkdown(md);
+
+assert.strictEqual(parsed.cardId, card._id);
+assert.strictEqual(parsed.remId, rem._id);
+assert.deepStrictEqual(parsed.tags, rem.tags);
+assert.strictEqual(parsed.difficulty, card.difficulty);
+assert.strictEqual(parsed.stability, card.stability);
+assert.strictEqual(parsed.lastReviewed, new Date(card.lastRepetitionTime!).toISOString());
+assert.strictEqual(parsed.nextDue, new Date(card.nextRepetitionTime!).toISOString());
+assert.strictEqual(parsed.question, rem.text);
+assert.strictEqual(parsed.answer, rem.backText);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add a markdown serializer and parser
- provide basic unit test using ts-node
- expose npm test script

## Testing
- `npm run test`
