### PR TITLE
Add sync widget and commands

### DIFF
--- a/src/github/sync.ts
+++ b/src/github/sync.ts
@@ -442,3 +442,21 @@ export async function pullUpdates(plugin: ReactRNPlugin) {
   }
 
 }
+
+export async function pushAllCards(plugin: ReactRNPlugin) {
+  const cards = await plugin.card.getAll();
+  for (const c of cards) {
+    await pushCardById(plugin, c._id);
+  }
+}
+
+export async function syncNow(plugin: ReactRNPlugin): Promise<boolean> {
+  try {
+    await pullUpdates(plugin);
+    await pushAllCards(plugin);
+    return true;
+  } catch (err) {
+    console.error('Sync failed', err);
+    return false;
+  }
+}

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -11,6 +11,8 @@ import {
   saveShaMap,
   fileShaMap,
   pullUpdates,
+  pushAllCards,
+  syncNow,
 } from '../github/sync';
 import '../style.css';
 import '../App.css';
@@ -85,18 +87,35 @@ async function onActivate(plugin: ReactRNPlugin) {
   });
 
   await plugin.app.registerCommand({
-    id: 'github-pull',
-    name: 'GitHub: Pull Updates',
+    id: 'github-sync-pull',
+    name: 'github-sync pull',
     action: async () => {
       await pullUpdates(plugin);
+      await plugin.storage.setLocal('sync-status', 'Synced');
+      await plugin.app.toast('Pulled updates from GitHub', 'info');
     },
   });
 
-  // Show a toast notification to the user.
-  await plugin.app.toast("I'm a toast!");
+  await plugin.app.registerCommand({
+    id: 'github-sync-push',
+    name: 'github-sync push',
+    action: async () => {
+      try {
+        await pushAllCards(plugin);
+        await plugin.storage.setLocal('sync-status', 'Synced');
+        await plugin.app.toast('Pushed local changes to GitHub', 'success');
+      } catch (err) {
+        console.error(err);
+        await plugin.storage.setLocal('sync-status', 'Error');
+        await plugin.app.toast('Push to GitHub failed', 'error');
+      }
+    },
+  });
 
-  // Register a sidebar widget.
-  await plugin.app.registerWidget('sample_widget', WidgetLocation.RightSidebar, {
+  await plugin.storage.setLocal('sync-status', 'Synced');
+
+  // Register a sidebar widget showing sync status
+  await plugin.app.registerWidget('sync_widget', WidgetLocation.RightSidebar, {
     dimensions: { height: 'auto', width: '100%' },
   });
 

--- a/src/widgets/sync_widget.tsx
+++ b/src/widgets/sync_widget.tsx
@@ -1,0 +1,23 @@
+import { renderWidget, usePlugin, useTracker } from '@remnote/plugin-sdk';
+import { syncNow } from '../github/sync';
+
+export const SyncWidget = () => {
+  const plugin = usePlugin();
+  const status = useTracker(() => plugin.storage.getLocal<string>('sync-status') ?? 'Idle');
+
+  const onClick = async () => {
+    await plugin.storage.setLocal('sync-status', 'Syncing');
+    const success = await syncNow(plugin);
+    await plugin.storage.setLocal('sync-status', success ? 'Synced' : 'Error');
+    await plugin.app.toast(success ? 'Sync completed' : 'Sync failed', success ? 'info' : 'error');
+  };
+
+  return (
+    <div className="p-2">
+      <div className="mb-2">GitHub Sync Status: {status}</div>
+      <button className="rn-btn rn-btn-primary" onClick={onClick}>Sync Now</button>
+    </div>
+  );
+};
+
+renderWidget(SyncWidget);


### PR DESCRIPTION
## Summary
- add helper functions for full sync and pushing all cards
- implement sidebar widget to show sync status and run manual sync
- register slash commands `/github-sync pull` and `/github-sync push`
- show toast notifications on sync operations

## Testing
- `npm test`