### PR TITLE
Add Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,22 @@ Your PAT gives write access to the specified repository. Keep it secret and do n
 
 ## Running Tests
 
-This repository includes a small test that verifies markdown serialization. Run it with:
+This repository includes automated unit tests run with **Jest**. Execute them with:
 
 ```bash
 npm test
 ```
 
 All tests should pass.
+
+## Manual Verification
+
+To verify two-way syncing:
+
+1. Create a new GitHub repository and generate a Personal Access Token with `repo` scope.
+2. In a fresh RemNote knowledge base install this plugin and enter the token and repository info in its settings.
+3. Make a simple flashcard such as `Planet::Earth` and wait for it to appear in the repository as a Markdown file.
+4. Edit the answer text directly on GitHub and commit the change.
+5. Trigger **Sync Now** from the plugin sidebar and confirm the update shows in RemNote.
+6. Delete the card in RemNote and after syncing confirm the file is removed from GitHub.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check-types": "tsc",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --color --progress --no-open",
     "build": "npx remnote-plugin validate && shx rm -rf dist && cross-env NODE_ENV=production webpack --color --progress && shx cp README.md dist && cd dist && bestzip ../PluginZip.zip ./*",
-    "test": "ts-node tests/markdown.test.ts"
+    "test": "jest"
   },
   "dependencies": {
     "@remnote/plugin-sdk": "latest",
@@ -39,6 +39,9 @@
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.9.3"
+    "webpack-dev-server": "^4.9.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.4"
   }
 }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,0 +1,37 @@
+import { createOrUpdateFile } from '../src/github/api';
+
+const mockSettings = {
+  'github-repo': 'user/repo',
+  'github-token': 'TOKEN',
+  'github-branch': 'main',
+};
+
+const plugin: any = {
+  settings: {
+    getSetting: jest.fn((key: string) => mockSettings[key]),
+  },
+};
+
+describe('createOrUpdateFile', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ content: { sha: 'newsha' } }),
+    }) as any;
+  });
+
+  it('sends PUT request with encoded content', async () => {
+    const result = await createOrUpdateFile(plugin, 'cards/card1.md', 'hello');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/user/repo/contents/cards%2Fcard1.md',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({ Authorization: 'token TOKEN' }),
+      })
+    );
+    expect(result.ok).toBe(true);
+    expect(result.sha).toBe('newsha');
+  });
+});

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,35 +1,36 @@
-import assert from 'assert';
 import { serializeCard, parseCardMarkdown, SimpleCard, SimpleRem } from '../src/github/markdown';
 
-const card: SimpleCard = {
-  _id: 'card-efgh5678',
-  remId: 'rem-abcd1234',
-  difficulty: 5.6,
-  stability: 15.2,
-  lastRepetitionTime: Date.parse('2025-04-10T09:30:00Z'),
-  nextRepetitionTime: Date.parse('2025-05-10T09:30:00Z'),
-};
+describe('markdown serialization', () => {
+  it('serializes and parses a card', () => {
+    const card: SimpleCard = {
+      _id: 'card-efgh5678',
+      remId: 'rem-abcd1234',
+      difficulty: 5.6,
+      stability: 15.2,
+      lastRepetitionTime: Date.parse('2025-04-10T09:30:00Z'),
+      nextRepetitionTime: Date.parse('2025-05-10T09:30:00Z'),
+    };
 
-const rem: SimpleRem = {
-  _id: 'rem-abcd1234',
-  text: 'Why does the sky appear blue during the day?',
-  backText: 'Rayleigh scattering causes blue light to dominate the sky.',
-  tags: ['Astronomy', 'LightScattering'],
-  updatedAt: Date.parse('2025-04-11T10:00:00Z'),
-};
+    const rem: SimpleRem = {
+      _id: 'rem-abcd1234',
+      text: 'Why does the sky appear blue during the day?',
+      backText: 'Rayleigh scattering causes blue light to dominate the sky.',
+      tags: ['Astronomy', 'LightScattering'],
+      updatedAt: Date.parse('2025-04-11T10:00:00Z'),
+    };
 
-const md = serializeCard(card, rem);
-const parsed = parseCardMarkdown(md);
+    const md = serializeCard(card, rem);
+    const parsed = parseCardMarkdown(md);
 
-assert.strictEqual(parsed.cardId, card._id);
-assert.strictEqual(parsed.remId, rem._id);
-assert.deepStrictEqual(parsed.tags, rem.tags);
-assert.strictEqual(parsed.difficulty, card.difficulty);
-assert.strictEqual(parsed.stability, card.stability);
-assert.strictEqual(parsed.lastReviewed, new Date(card.lastRepetitionTime!).toISOString());
-assert.strictEqual(parsed.nextDue, new Date(card.nextRepetitionTime!).toISOString());
-assert.strictEqual(parsed.question, rem.text);
-assert.strictEqual(parsed.answer, rem.backText);
-assert.strictEqual(parsed.updated, new Date(rem.updatedAt!).toISOString());
-
-console.log('All tests passed.');
+    expect(parsed.cardId).toBe(card._id);
+    expect(parsed.remId).toBe(rem._id);
+    expect(parsed.tags).toEqual(rem.tags);
+    expect(parsed.difficulty).toBe(card.difficulty);
+    expect(parsed.stability).toBe(card.stability);
+    expect(parsed.lastReviewed).toBe(new Date(card.lastRepetitionTime!).toISOString());
+    expect(parsed.nextDue).toBe(new Date(card.nextRepetitionTime!).toISOString());
+    expect(parsed.question).toBe(rem.text);
+    expect(parsed.answer).toBe(rem.backText);
+    expect(parsed.updated).toBe(new Date(rem.updatedAt!).toISOString());
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config and dev dependencies
- convert markdown test to Jest and add API helper test
- document running tests and manual verification steps

## Testing
- `npm test` *(fails: jest not found)*