### PR TITLE
Add slugged filename option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin synchronizes your RemNote flashcards with a GitHub repository. Each 
 - **Automatic pull** – periodically fetches updates from GitHub and applies them to your knowledge base.
 - **Markdown format** – cards are saved as Markdown with YAML front‑matter including FSRS fields.
 - **Conflict handling** – basic conflict resolution with optional policies and conflict files.
-- **Settings** – configure repository, branch, subdirectory and whether auto push/pull is enabled.
+- **Settings** – configure repository, branch, subdirectory, slugged filenames and whether auto push/pull is enabled.
 
 ## Development Setup
 
@@ -39,6 +39,7 @@ The plugin requires a GitHub Personal Access Token (PAT) with access to the repo
    - **Repository (owner/repo)** – e.g. `username/flashcards`.
    - **Branch name** – branch used for sync (default `main`).
    - **Cards subdirectory** – optional folder within the repo for card files.
+   - **Use slugs in file names** – prefix files with a sanitized question slug.
    - Enable or disable **auto‑push** and **auto‑pull** as desired.
 
 ### Security Notes

--- a/src/github/sync.ts
+++ b/src/github/sync.ts
@@ -12,6 +12,7 @@ interface ShaEntry {
   sha: string;
   remId: string;
   timestamp: number;
+  slug?: string;
 }
 export let fileShaMap: Record<string, ShaEntry> = {};
 
@@ -34,12 +35,24 @@ export async function loadFailedQueue(plugin: ReactRNPlugin): Promise<string[]> 
   return (await plugin.storage.getSynced<string[]>(FAILED_QUEUE_KEY)) || [];
 }
 
-export async function saveFailedQueue(plugin: ReactRNPlugin, queue: string[]): Promise<void> {
+export async function saveFailedQueue(
+  plugin: ReactRNPlugin,
+  queue: string[]
+): Promise<void> {
   await plugin.storage.setSynced(FAILED_QUEUE_KEY, queue);
 }
 
-function getPath(subdir: string, cardId: string) {
-  return subdir ? `${subdir}/${cardId}.md` : `${cardId}.md`;
+function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+function getPath(subdir: string, cardId: string, slug?: string) {
+  const file = slug ? `${slug}_${cardId}.md` : `${cardId}.md`;
+  return subdir ? `${subdir}/${file}` : file;
 }
 
 async function createConflictFile(
@@ -120,6 +133,7 @@ export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
   if (!rem) return;
 
   const subdir = (await plugin.settings.getSetting<string>('github-subdir')) || '';
+  const useSlug = await plugin.settings.getSetting<boolean>('use-slug-filenames');
 
   const simpleCard: SimpleCard = {
     _id: card._id,
@@ -145,12 +159,21 @@ export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
   };
 
   const content = serializeCard(simpleCard, simpleRem);
-  const path = getPath(subdir, cardId);
+  let slug = fileShaMap[cardId]?.slug;
+  if (useSlug && !slug && text) {
+    slug = slugify(text);
+  }
+  const path = getPath(subdir, cardId, slug);
 
   const shaEntry = fileShaMap[cardId];
   const res = await createOrUpdateFile(plugin, path, content, shaEntry?.sha);
   if (res.ok && res.sha) {
-    fileShaMap[cardId] = { sha: res.sha, remId: rem._id, timestamp: Date.now() };
+    fileShaMap[cardId] = {
+      sha: res.sha,
+      remId: rem._id,
+      timestamp: Date.now(),
+      slug,
+    };
     const queue = await loadFailedQueue(plugin);
     const idx = queue.indexOf(cardId);
     if (idx !== -1) {
@@ -191,6 +214,7 @@ export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
           sha: remote.data.sha,
           remId: rem._id,
           timestamp: Date.now(),
+          slug,
         };
       } else {
         const retry = await createOrUpdateFile(plugin, path, content, remote.data.sha);
@@ -199,6 +223,7 @@ export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
             sha: retry.sha,
             remId: rem._id,
             timestamp: Date.now(),
+            slug,
           };
         } else {
           const queue = await loadFailedQueue(plugin);
@@ -222,7 +247,7 @@ export async function deleteCardFile(plugin: ReactRNPlugin, cardId: string) {
   const entry = fileShaMap[cardId];
   if (!entry) return;
   const subdir = (await plugin.settings.getSetting<string>('github-subdir')) || '';
-  const path = getPath(subdir, cardId);
+  const path = getPath(subdir, cardId, entry.slug);
   const res = await deleteFile(plugin, path, entry.sha);
   if (res.ok) {
     delete fileShaMap[cardId];
@@ -249,8 +274,12 @@ export async function pullUpdates(plugin: ReactRNPlugin) {
   const seen = new Set<string>();
 
   for (const file of files) {
-    const id = file.path.split('/').pop()?.replace(/\.md$/, '');
+    const filename = file.path.split('/').pop() ?? '';
+    const base = filename.replace(/\.md$/, '');
+    const parts = base.split('_');
+    const id = parts.pop();
     if (!id) continue;
+    const slug = parts.length > 0 ? parts.join('_') : undefined;
     seen.add(id);
     const entry = fileShaMap[id];
     if (!entry || entry.sha !== file.sha) {
@@ -402,7 +431,12 @@ export async function pullUpdates(plugin: ReactRNPlugin) {
         }
       }
 
-      fileShaMap[id] = { sha: file.sha, remId: rem._id, timestamp: Date.now() };
+      fileShaMap[id] = {
+        sha: file.sha,
+        remId: rem._id,
+        timestamp: Date.now(),
+        slug,
+      };
     }
   }
 

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -55,6 +55,13 @@ async function onActivate(plugin: ReactRNPlugin) {
   });
 
   await plugin.settings.registerBooleanSetting({
+    id: 'use-slug-filenames',
+    title: 'Use slugs in file names',
+    description: 'Prefix files with a slug of the question text',
+    defaultValue: false,
+  });
+
+  await plugin.settings.registerBooleanSetting({
     id: 'auto-push',
     title: 'Enable auto-push',
     description: 'Automatically push local changes to GitHub',


### PR DESCRIPTION
## Summary
- support optional slugged filenames in GitHub sync
- keep slug in SHA map so files don't move when questions change
- expose a `Use slugs in file names` boolean setting
- document slug option in README

## Testing
- `npm test`