### PR TITLE
Add image media sync support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This plugin synchronizes your RemNote flashcards with a GitHub repository. Each 
 - **Automatic push** – card edits, reviews and tag changes in RemNote are committed to GitHub.
 - **Automatic pull** – periodically fetches updates from GitHub and applies them to your knowledge base.
 - **Markdown format** – cards are saved as Markdown with YAML front‑matter including FSRS fields.
+- **Media support** – images in cards are stored under `media/` in the repository and linked from Markdown.
 - **Conflict handling** – basic conflict resolution with optional policies and conflict files.
 - **Settings** – configure repository, branch, subdirectory and whether auto push/pull is enabled.
 

--- a/src/github/markdown.ts
+++ b/src/github/markdown.ts
@@ -14,6 +14,8 @@ export interface SimpleRem {
   backText?: string;
   tags?: string[];
   updatedAt?: number;
+  textRich?: any;
+  backRich?: any;
 }
 
 export interface ParsedCard {
@@ -33,7 +35,14 @@ export interface ParsedCard {
 /**
  * Serialize a card/rem pair to a markdown string with YAML frontmatter.
  */
-export function serializeCard(card: SimpleCard, rem: SimpleRem): string {
+import { ReactRNPlugin } from '@remnote/plugin-sdk';
+import { createOrUpdateBinaryFile, getBinaryFile } from './api';
+
+export async function serializeCard(
+  plugin: ReactRNPlugin,
+  card: SimpleCard,
+  rem: SimpleRem
+): Promise<string> {
   const frontmatter: Record<string, any> = {
     remId: rem._id,
     cardId: card._id,
@@ -52,15 +61,29 @@ export function serializeCard(card: SimpleCard, rem: SimpleRem): string {
 
   const yaml = require('yaml');
   const front = yaml.stringify(frontmatter).trimEnd();
-  const question = rem.text ?? '';
-  const answer = rem.backText ?? '';
+
+  let question = rem.text ?? '';
+  let answer = rem.backText ?? '';
+
+  if (rem.textRich) {
+    question = await plugin.richText.toMarkdown(rem.textRich);
+    question = await processImages(plugin, question);
+  }
+  if (rem.backRich) {
+    answer = await plugin.richText.toMarkdown(rem.backRich);
+    answer = await processImages(plugin, answer);
+  }
+
   return `---\n${front}\n---\n**Q:** ${question}\n\n**A:** ${answer}\n`;
 }
 
 /**
  * Parse a markdown string created by `serializeCard` back into its components.
  */
-export function parseCardMarkdown(content: string): ParsedCard {
+export async function parseCardMarkdown(
+  plugin: ReactRNPlugin,
+  content: string
+): Promise<ParsedCard> {
   const yaml = require('yaml');
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!fmMatch) {
@@ -74,16 +97,19 @@ export function parseCardMarkdown(content: string): ParsedCard {
   if (qIndex === -1 || aIndex === -1 || aIndex < qIndex) {
     throw new Error('Invalid card markdown: missing Q/A');
   }
-  const question = lines
+  let question = lines
     .slice(qIndex, aIndex)
     .join('\n')
     .replace(/^\*\*Q:\*\*\s*/, '')
     .trim();
-  const answer = lines
+  let answer = lines
     .slice(aIndex)
     .join('\n')
     .replace(/^\*\*A:\*\*\s*/, '')
     .trim();
+
+  question = await restoreImages(plugin, question);
+  answer = await restoreImages(plugin, answer);
   return {
     cardId: front.cardId,
     remId: front.remId,
@@ -97,4 +123,67 @@ export function parseCardMarkdown(content: string): ParsedCard {
     question,
     answer,
   };
+}
+
+async function processImages(plugin: ReactRNPlugin, text: string): Promise<string> {
+  const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
+  const subdir = (await plugin.settings.getSetting<string>('github-subdir')) || '';
+  const mediaDir = subdir ? `${subdir}/media` : 'media';
+  let result = '';
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = imageRegex.exec(text))) {
+    result += text.slice(last, match.index);
+    const alt = match[1];
+    let url = match[2];
+    let base64: string | null = null;
+    if (url.startsWith('data:')) {
+      base64 = url.split(',')[1];
+    } else {
+      try {
+        const res = await fetch(url);
+        const buffer = await res.arrayBuffer();
+        base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
+      } catch {
+        base64 = null;
+      }
+    }
+    if (base64) {
+      const extMatch = url.match(/\.([a-zA-Z0-9]+)(?:$|\?)/);
+      const ext = extMatch ? extMatch[1] : 'png';
+      const fileName = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+      const path = `${mediaDir}/${fileName}`;
+      await createOrUpdateBinaryFile(plugin, path, base64);
+      url = path;
+    }
+    result += `![${alt}](${url})`;
+    last = imageRegex.lastIndex;
+  }
+  result += text.slice(last);
+  return result;
+}
+
+async function restoreImages(plugin: ReactRNPlugin, text: string): Promise<string> {
+  const imageRegex = /!\[([^\]]*)\]\((media\/[^)]+)\)/g;
+  const subdir = (await plugin.settings.getSetting<string>('github-subdir')) || '';
+  let result = '';
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = imageRegex.exec(text))) {
+    result += text.slice(last, match.index);
+    const alt = match[1];
+    const relPath = match[2];
+    const fullPath = subdir ? `${subdir}/${relPath}` : relPath;
+    const file = await getBinaryFile(plugin, fullPath);
+    let url = relPath;
+    if (file.ok && file.data) {
+      const ext = relPath.split('.').pop() || 'png';
+      const mime = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' : `image/${ext}`;
+      url = `data:${mime};base64,${file.data.content}`;
+    }
+    result += `![${alt}](${url})`;
+    last = imageRegex.lastIndex;
+  }
+  result += text.slice(last);
+  return result;
 }

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,7 +1,27 @@
 import { serializeCard, parseCardMarkdown, SimpleCard, SimpleRem } from '../src/github/markdown';
+import { createOrUpdateBinaryFile, getBinaryFile } from '../src/github/api';
+
+jest.mock('../src/github/api', () => {
+  const original = jest.requireActual('../src/github/api');
+  return {
+    ...original,
+    createOrUpdateBinaryFile: jest.fn(async () => ({ ok: true, status: 200, sha: 'sha1' })),
+    getBinaryFile: jest.fn(async () => ({ ok: true, status: 200, data: { content: 'aW1n' , sha: 'sha1' } })),
+  };
+});
+
+const plugin: any = {
+  richText: {
+    toMarkdown: jest.fn(async (rt: any) => rt),
+    parseFromMarkdown: jest.fn(async (md: string) => md),
+  },
+  settings: {
+    getSetting: jest.fn(async () => ''),
+  },
+};
 
 describe('markdown serialization', () => {
-  it('serializes and parses a card', () => {
+  it('serializes and parses a card', async () => {
     const card: SimpleCard = {
       _id: 'card-efgh5678',
       remId: 'rem-abcd1234',
@@ -19,8 +39,8 @@ describe('markdown serialization', () => {
       updatedAt: Date.parse('2025-04-11T10:00:00Z'),
     };
 
-    const md = serializeCard(card, rem);
-    const parsed = parseCardMarkdown(md);
+    const md = await serializeCard(plugin, card, rem);
+    const parsed = await parseCardMarkdown(plugin, md);
 
     expect(parsed.cardId).toBe(card._id);
     expect(parsed.remId).toBe(rem._id);
@@ -32,5 +52,27 @@ describe('markdown serialization', () => {
     expect(parsed.question).toBe(rem.text);
     expect(parsed.answer).toBe(rem.backText);
     expect(parsed.updated).toBe(new Date(rem.updatedAt!).toISOString());
+  });
+
+  it('handles images', async () => {
+    const card: SimpleCard = { _id: 'c1', remId: 'r1' };
+    const imgData = 'data:image/png;base64,aW1n';
+    const rem: SimpleRem = {
+      _id: 'r1',
+      textRich: [{ i: 'i', url: imgData }],
+      backRich: [{ i: 'i', url: imgData }],
+    } as any;
+
+    plugin.richText.toMarkdown.mockImplementation(async (rt: any) => {
+      return rt.map((e: any) => `![img](${e.url})`).join('');
+    });
+
+    const md = await serializeCard(plugin, card, rem);
+    expect(createOrUpdateBinaryFile).toHaveBeenCalled();
+    expect(md).toContain('media/');
+
+    const parsed = await parseCardMarkdown(plugin, md);
+    expect(parsed.question).toContain('data:image/png;base64');
+    expect(parsed.answer).toContain('data:image/png;base64');
   });
 });


### PR DESCRIPTION
## Summary
- support binary media upload/download with GitHub API
- handle images in flashcards when serializing and parsing
- update sync logic to use new async helpers
- add tests for cards containing images
- document media support

## Testing
- `npm test`