### PR TITLE
Support SM2 scheduler fields

### DIFF
--- a/src/github/sync.ts
+++ b/src/github/sync.ts
@@ -111,6 +111,12 @@ async function applyParsedToRem(
   if (parsed.stability !== null && parsed.stability !== undefined) {
     (card as any).stability = parsed.stability;
   }
+  if (parsed.ease !== null && parsed.ease !== undefined) {
+    (card as any).ease = parsed.ease;
+  }
+  if (parsed.interval !== null && parsed.interval !== undefined) {
+    (card as any).interval = parsed.interval;
+  }
 }
 
 export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
@@ -121,6 +127,18 @@ export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
 
   const subdir = (await plugin.settings.getSetting<string>('github-subdir')) || '';
 
+  let scheduler =
+    (await plugin.settings.getSetting<string>('scheduler')) || undefined;
+  if (!scheduler) {
+    if ((card as any).difficulty !== undefined || (card as any).stability !== undefined) {
+      scheduler = 'FSRS';
+    } else if ((card as any).ease !== undefined || (card as any).interval !== undefined) {
+      scheduler = 'SM2';
+    } else {
+      scheduler = 'FSRS';
+    }
+  }
+
   const simpleCard: SimpleCard = {
     _id: card._id,
     remId: card.remId,
@@ -128,6 +146,9 @@ export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
     lastRepetitionTime: card.lastRepetitionTime,
     difficulty: (card as any).difficulty,
     stability: (card as any).stability,
+    ease: (card as any).ease,
+    interval: (card as any).interval,
+    scheduler,
   };
 
   const text = rem.text ? await plugin.richText.toString(rem.text) : undefined;
@@ -283,6 +304,14 @@ export async function pullUpdates(plugin: ReactRNPlugin) {
               lastRepetitionTime: card!.lastRepetitionTime,
               difficulty: (card as any).difficulty,
               stability: (card as any).stability,
+              ease: (card as any).ease,
+              interval: (card as any).interval,
+              scheduler:
+                (await plugin.settings.getSetting<string>('scheduler')) ||
+                ((card as any).difficulty !== undefined ||
+                (card as any).stability !== undefined
+                  ? 'FSRS'
+                  : 'SM2'),
             };
             const text = rem.text
               ? await plugin.richText.toString(rem.text)
@@ -399,6 +428,12 @@ export async function pullUpdates(plugin: ReactRNPlugin) {
         }
         if (parsed.stability !== null && parsed.stability !== undefined) {
           (card as any).stability = parsed.stability;
+        }
+        if (parsed.ease !== null && parsed.ease !== undefined) {
+          (card as any).ease = parsed.ease;
+        }
+        if (parsed.interval !== null && parsed.interval !== undefined) {
+          (card as any).interval = parsed.interval;
         }
       }
 

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,12 +1,13 @@
 import { serializeCard, parseCardMarkdown, SimpleCard, SimpleRem } from '../src/github/markdown';
 
 describe('markdown serialization', () => {
-  it('serializes and parses a card', () => {
+  it('serializes and parses a FSRS card', () => {
     const card: SimpleCard = {
       _id: 'card-efgh5678',
       remId: 'rem-abcd1234',
       difficulty: 5.6,
       stability: 15.2,
+      scheduler: 'FSRS',
       lastRepetitionTime: Date.parse('2025-04-10T09:30:00Z'),
       nextRepetitionTime: Date.parse('2025-05-10T09:30:00Z'),
     };
@@ -32,5 +33,35 @@ describe('markdown serialization', () => {
     expect(parsed.question).toBe(rem.text);
     expect(parsed.answer).toBe(rem.backText);
     expect(parsed.updated).toBe(new Date(rem.updatedAt!).toISOString());
+  });
+
+  it('serializes and parses an SM2 card', () => {
+    const card: SimpleCard = {
+      _id: 'card-sm2',
+      remId: 'rem-sm2',
+      ease: 2.5,
+      interval: 10,
+      scheduler: 'SM2',
+      lastRepetitionTime: Date.parse('2025-01-01T00:00:00Z'),
+      nextRepetitionTime: Date.parse('2025-01-11T00:00:00Z'),
+    };
+
+    const rem: SimpleRem = {
+      _id: 'rem-sm2',
+      text: 'Q?',
+      backText: 'A',
+      tags: ['Tag1'],
+      updatedAt: Date.parse('2025-01-02T00:00:00Z'),
+    };
+
+    const md = serializeCard(card, rem);
+    const parsed = parseCardMarkdown(md);
+
+    expect(parsed.cardId).toBe(card._id);
+    expect(parsed.scheduler).toBe('SM2');
+    expect(parsed.ease).toBe(card.ease);
+    expect(parsed.interval).toBe(card.interval);
+    expect(parsed.question).toBe(rem.text);
+    expect(parsed.answer).toBe(rem.backText);
   });
 });


### PR DESCRIPTION
## Summary
- extend `SimpleCard` and `ParsedCard` with SM2 fields
- include scheduler-specific fields in markdown serialization
- parse the new SM2 frontmatter fields
- detect scheduler and write correct values when pushing cards
- handle scheduler fields when pulling updates
- test markdown helpers for both FSRS and SM2 cards

## Testing
- `npm test`