### PR TITLE
Add media sync to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This plugin synchronizes your RemNote flashcards with a GitHub repository. Each 
 - **Automatic push** – card edits, reviews and tag changes in RemNote are committed to GitHub.
 - **Automatic pull** – periodically fetches updates from GitHub and applies them to your knowledge base.
 - **Markdown format** – cards are saved as Markdown with YAML front‑matter including FSRS fields.
+- **Media support** – images in your cards are uploaded to a `media/` folder and referenced from Markdown.
 - **Conflict handling** – if a card is edited in both places the plugin creates a file in `conflicts/`, adds the card ID under a *Conflicts* document in your KB and shows a toast so you can resolve it manually.
 - **Settings** – configure repository, branch, subdirectory, slugged filenames and whether auto push/pull is enabled.
 - **Configurable intervals** – set how often auto-pull and retry timers run.

--- a/src/github/sync.ts
+++ b/src/github/sync.ts
@@ -6,7 +6,13 @@ import {
   parseCardMarkdown,
   ParsedCard,
 } from './markdown';
-import { createOrUpdateFile, deleteFile, getFile, listFiles } from './api';
+import {
+  createOrUpdateFile,
+  deleteFile,
+  getFile,
+  listFiles,
+  getBinaryFile,
+} from './api';
 
 interface ShaEntry {
   sha: string;
@@ -99,8 +105,39 @@ async function applyParsedToRem(
   rem: any,
   card: any
 ) {
-  await rem.setText(await plugin.richText.parseFromMarkdown(parsed.question));
-  await rem.setBackText(await plugin.richText.parseFromMarkdown(parsed.answer));
+  const replaceMedia = async (text: string) => {
+    const regex = /!\[(.*?)\]\((media\/[^)]+)\)/g;
+    let result = '';
+    let last = 0;
+    for (const match of text.matchAll(regex)) {
+      result += text.slice(last, match.index);
+      last = (match.index || 0) + match[0].length;
+      const alt = match[1];
+      const path = match[2];
+      const file = await getBinaryFile(plugin, path);
+      if (file.ok && file.data) {
+        const ext = path.split('.').pop()?.toLowerCase() || 'png';
+        const mime = ext === 'jpg' || ext === 'jpeg'
+          ? 'image/jpeg'
+          : ext === 'gif'
+          ? 'image/gif'
+          : ext === 'svg'
+          ? 'image/svg+xml'
+          : 'image/png';
+        const base64 = Buffer.from(file.data.content).toString('base64');
+        result += `![${alt}](data:${mime};base64,${base64})`;
+      } else {
+        result += match[0];
+      }
+    }
+    result += text.slice(last);
+    return result;
+  };
+
+  const q = await replaceMedia(parsed.question);
+  const a = await replaceMedia(parsed.answer);
+  await rem.setText(await plugin.richText.parseFromMarkdown(q));
+  await rem.setBackText(await plugin.richText.parseFromMarkdown(a));
 
   const currentTags = await rem.getTagRems();
   const currentNames = await Promise.all(
@@ -190,8 +227,8 @@ export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
     scheduler,
   };
 
-  const text = rem.text ? await plugin.richText.toString(rem.text) : undefined;
-  const backText = rem.backText ? await plugin.richText.toString(rem.backText) : undefined;
+  const text = rem.text ? await plugin.richText.toMarkdown(rem.text) : undefined;
+  const backText = rem.backText ? await plugin.richText.toMarkdown(rem.backText) : undefined;
   const tagRems = await rem.getTagRems();
   const tags = await Promise.all(
     tagRems.map(async (t: any) => (t.text ? await plugin.richText.toString(t.text) : ''))
@@ -204,7 +241,7 @@ export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
     updatedAt: rem.updatedAt,
   };
 
-  const content = serializeCard(simpleCard, simpleRem);
+  const content = await serializeCard(plugin, simpleCard, simpleRem);
   let slug = fileShaMap[cardId]?.slug;
   if (useSlug && !slug && text) {
     slug = slugify(text);
@@ -373,10 +410,10 @@ export async function pullUpdates(plugin: ReactRNPlugin) {
                   : 'SM2'),
             };
             const text = rem.text
-              ? await plugin.richText.toString(rem.text)
+              ? await plugin.richText.toMarkdown(rem.text)
               : undefined;
             const backText = rem.backText
-              ? await plugin.richText.toString(rem.backText)
+              ? await plugin.richText.toMarkdown(rem.backText)
               : undefined;
             const tagRems = await rem.getTagRems();
             const tags = await Promise.all(
@@ -391,7 +428,7 @@ export async function pullUpdates(plugin: ReactRNPlugin) {
               tags,
               updatedAt: rem.updatedAt,
             };
-            const localContent = serializeCard(simpleCard, simpleRem);
+            const localContent = await serializeCard(plugin, simpleCard, simpleRem);
             await createConflictFile(
               plugin,
               subdir,

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -18,7 +18,8 @@ function createPlugin() {
     settings: { getSetting: jest.fn((k: string) => settings[k]) },
     card: { findOne: jest.fn(), getAll: jest.fn() },
     richText: {
-      toString: jest.fn(async (t: any) => t),
+      toString: jest.fn(async (t: any) => (typeof t === 'string' ? t : t.text)),
+      toMarkdown: jest.fn(async (t: any) => (typeof t === 'string' ? t : t.text)),
       parseFromMarkdown: jest.fn(async (t: any) => t),
     },
     rem: {
@@ -29,6 +30,7 @@ function createPlugin() {
       getSynced: jest.fn().mockResolvedValue([]),
       setSynced: jest.fn(),
     },
+    app: { toast: jest.fn() },
   } as any;
 }
 
@@ -79,6 +81,7 @@ describe('pushCardById', () => {
       lastRepetitionTime: 50,
       difficulty: undefined,
       stability: undefined,
+      scheduler: 'FSRS',
     };
     const simpleRem = {
       _id: 'rem1',
@@ -87,7 +90,7 @@ describe('pushCardById', () => {
       tags: ['tag1'],
       updatedAt: 100,
     };
-    const content = serializeCard(simpleCard as any, simpleRem as any);
+    const content = await serializeCard(plugin as any, simpleCard as any, simpleRem as any);
     expect(createOrUpdateFile).toHaveBeenCalledWith(plugin, 'cards/card1.md', content, undefined);
     expect(fileShaMap['card1'].sha).toBe('newsha');
   });
@@ -103,7 +106,7 @@ describe('pushCardById', () => {
     createOrUpdateFile.mockResolvedValueOnce({ ok: false, status: 409 });
     const remoteCard = { ...card, nextRepetitionTime: 300, lastRepetitionTime: 70 };
     const remoteRem = { ...rem, text: 'Q2', backText: 'A2', updatedAt: 200 };
-    const remoteContent = serializeCard(remoteCard as any, remoteRem as any);
+    const remoteContent = await serializeCard(plugin as any, remoteCard as any, remoteRem as any);
     getFile.mockResolvedValue({ ok: true, status: 200, data: { content: remoteContent, sha: 'remotesha' } });
 
     await pushCardById(plugin, 'card1');
@@ -126,7 +129,7 @@ describe('pullUpdates', () => {
     listFiles.mockResolvedValue({ ok: true, files: [{ path: 'cards/card1.md', sha: 'new' }] });
     const remoteCard = { ...card };
     const remoteRem = { ...rem };
-    const remoteContent = serializeCard(remoteCard as any, remoteRem as any);
+    const remoteContent = await serializeCard(plugin as any, remoteCard as any, remoteRem as any);
     getFile.mockResolvedValue({ ok: true, status: 200, data: { content: remoteContent, sha: 'new' } });
     createOrUpdateFile.mockResolvedValue({ ok: true, status: 200, sha: 'confsha' });
 


### PR DESCRIPTION
## Summary
- support uploading/downloading media files
- detect images when serializing cards
- parse media links when importing from GitHub
- include media syncing in tests
- document media support

## Testing
- `npm test`