### PR TITLE
Add scheduler dropdown setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The plugin requires a GitHub Personal Access Token (PAT) with access to the repo
 - Enable or disable **auto‑push** and **auto‑pull** as desired.
 - **Auto Pull Interval (minutes)** – how frequently to check GitHub for updates (default 5).
 - **Retry Interval (minutes)** – how often failed pushes are retried (default 5).
+- **Scheduler** – choose `FSRS` or `SM2` for card scheduling metadata.
 
 ### Security Notes
 

--- a/src/github/sync.ts
+++ b/src/github/sync.ts
@@ -228,15 +228,15 @@ export async function pushCardById(plugin: ReactRNPlugin, cardId: string) {
   const subdir = (await plugin.settings.getSetting<string>('github-subdir')) || '';
   const useSlug = await plugin.settings.getSetting<boolean>('use-slug-filenames');
 
-  let scheduler =
-    (await plugin.settings.getSetting<string>('scheduler')) || undefined;
+  const userChoice = await plugin.settings.getSetting<string>('scheduler');
+  let scheduler = userChoice || undefined;
   if (!scheduler) {
     if ((card as any).difficulty !== undefined || (card as any).stability !== undefined) {
       scheduler = 'FSRS';
     } else if ((card as any).ease !== undefined || (card as any).interval !== undefined) {
       scheduler = 'SM2';
     } else {
-      scheduler = 'FSRS';
+      scheduler = userChoice || 'FSRS';
     }
   }
 

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -116,6 +116,17 @@ async function onActivate(plugin: ReactRNPlugin) {
     defaultValue: 5,
   });
 
+  await plugin.settings.registerDropdownSetting({
+    id: 'scheduler',
+    title: 'Scheduler',
+    description: 'Select FSRS or SM2 for card metadata',
+    options: [
+      { key: 'fsrs', label: 'FSRS', value: 'FSRS' },
+      { key: 'sm2', label: 'SM2', value: 'SM2' },
+    ],
+    defaultValue: 'FSRS',
+  });
+
   await plugin.settings.registerStringSetting({
     id: 'conflict-policy',
     title: 'Conflict Resolution Policy',

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -13,6 +13,7 @@ function createPlugin() {
   const settings: Record<string, any> = {
     'github-subdir': 'cards',
     'conflict-policy': 'newer',
+    scheduler: 'FSRS',
   };
   return {
     settings: { getSetting: jest.fn((k: string) => settings[k]) },
@@ -32,7 +33,6 @@ function createPlugin() {
       getSynced: jest.fn().mockResolvedValue([]),
       setSynced: jest.fn(),
     },
-    app: { toast: jest.fn() },
   } as any;
 }
 


### PR DESCRIPTION
## Summary
- allow selecting scheduler algorithm via new `scheduler` dropdown setting
- default to the user's scheduler choice when pushing cards
- document the new setting in README
- update tests for new setting

## Testing
- `npm test`